### PR TITLE
ignore empty object and plain string in function tok()

### DIFF
--- a/lib/kramed.js
+++ b/lib/kramed.js
@@ -1002,6 +1002,9 @@ Parser.prototype.parseText = function() {
  */
 
 Parser.prototype.tok = function() {
+  if(typeof this.token === 'undefined' || !this.token.hasOwnProperty('type')) {
+      return '';
+  }
   switch (this.token.type) {
     case 'space': {
       return '';


### PR DESCRIPTION
empty objects and plain strings in variable 'this.tokens' will result
in additional 'undefined' string in the output of the
'Parser.prototype.parse' function.It will pollute the search_index.json,
product a lot of 'undefinedundefined...' index.
