### PR TITLE
Heading mods

### DIFF
--- a/lib/kramed.js
+++ b/lib/kramed.js
@@ -846,7 +846,7 @@ Renderer.prototype.html = function(html) {
 };
 
 Renderer.prototype.heading = function(text, level, raw) {
-  id = /({#)(.+)(})/g.exec(raw);
+  var id = /({#)(.+)(})/g.exec(raw);
   return '<h'
     + level
     + ' id="'


### PR DESCRIPTION
Here's a quick pass at adding the behavior specified in this issue https://github.com/GitbookIO/kramed/issues/4

This idea is to
- _replace_ the header ID with the specified one instead of concatenating
- remove the trailing hyphens in resultant ID
- remove the attribute block {#...} from the resulting output

I'm fairly new to regex, so I'd expect that this could be made more robust. 

This approach fails on more than one `#ID` in the atrribute block `{#ID}`

Wishlist for these mods would be to match this behavior https://michelf.ca/projects/php-markdown/extra/#spe-attr so there can be multiple IDs and Classes passed through the attribute block. It'll probably be slower, so this can be called '**Kramed, built for speed***'
