### PR TITLE
discriminate between en-dash, em-dash

### DIFF
--- a/lib/kramed.js
+++ b/lib/kramed.js
@@ -772,7 +772,9 @@ InlineLexer.prototype.smartypants = function(text) {
   if (!this.options.smartypants) return text;
   return text
     // em-dashes
-    .replace(/--/g, '\u2014')
+    .replace(/---/g, '\u2014')
+    // en-dashes
+    .replace(/--/g, '\u2013')
     // opening singles
     .replace(/(^|[-\u2014/(\[{"\s])'/g, '$1\u2018')
     // closing singles & apostrophes


### PR DESCRIPTION
Typically, en-dashes are created by double dashes `--`, em-dashes by triple dashes `---` (e.g., [compose key syntax](http://en.wikipedia.org/wiki/Wikipedia:How_to_make_dashes) or [LaTeX](http://tex.stackexchange.com/a/3821/13262)). This pull request implements this behavior.
