### PR TITLE
Add option to disable generating ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
 node_modules
+
+.DS_Store

--- a/lib/kramed.js
+++ b/lib/kramed.js
@@ -93,7 +93,7 @@ function kramed(src, opt, callback) {
     return;
   }
   try {
-    if (opt) opt = merge({}, kramed.defaults, opt);
+    opt = merge({}, kramed.defaults, opt || {});
     return Parser.parse(Lexer.lex(src, opt), opt);
   } catch (e) {
     e.message += '\nPlease report this to https://github.com/GitbookIO/kramed.';

--- a/lib/kramed.js
+++ b/lib/kramed.js
@@ -134,6 +134,7 @@ kramed.defaults = {
   langPrefix: 'lang-',
   smartypants: false,
   headerPrefix: '',
+  autoIds: true,
   xhtml: false,
 
   // Default rendrer passed to Parser

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -10,6 +10,7 @@ var defaultOptions = {
   langPrefix: 'lang-',
   smartypants: false,
   headerPrefix: '',
+  autoIds: true,
   xhtml: false,
 };
 
@@ -60,14 +61,20 @@ Renderer.prototype._createId = function(str) {
 };
 
 Renderer.prototype.heading = function(text, level, raw) {
-  var id = /({#)(.+)(})/g.exec(raw);
+  var hash = /\s({#)(.+)(})/g.exec(raw);
+  var id = '';
+
+  if (id) {
+    id = ' id="' + hash[2] + '"';
+  } else if(this.options.autoIds) {
+    id = ' id="' + this.options.headerPrefix + this._createId(raw) + '"';
+  }
+
   return '<h'
     + level
-    + ' id="'
-    + this.options.headerPrefix
-    + (id ? id[2] : this._createId(raw))
-    + '">'
-    + text.replace(/{#.+}/g, '')
+    + id
+    + '>'
+    + text.replace(/\s{#.+}/g, '')
     + '</h'
     + level
     + '>\n';

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,6 +1,7 @@
 var _utils = require('./utils');
 var escape = _utils.escape;
 var unescape = _utils.unescape;
+var merge = _utils.merge;
 
 /**
  * Renderer
@@ -15,7 +16,7 @@ var defaultOptions = {
 };
 
 function Renderer(options) {
-  this.options = options || defaultOptions;
+  this.options = merge(defaultOptions, options || {});
 }
 
 Renderer.prototype.code = function(code, lang, escaped) {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -61,10 +61,10 @@ Renderer.prototype._createId = function(str) {
 };
 
 Renderer.prototype.heading = function(text, level, raw) {
-  var hash = /\s({#)(.+)(})/g.exec(raw);
+  var hash = /(\s{#)(.+)(})/g.exec(raw);
   var id = '';
 
-  if (id) {
+  if (hash) {
     id = ' id="' + hash[2] + '"';
   } else if(this.options.autoIds) {
     id = ' id="' + this.options.headerPrefix + this._createId(raw) + '"';

--- a/test/tests/header_id.html
+++ b/test/tests/header_id.html
@@ -5,3 +5,5 @@
 <h2 id="no-ascii-%E4%B8%AD%E6%96%87">no ascii 中文</h2>
 
 <h3 id="special-characters-%EF%BF%BD">special characters � &#39;`&quot;|,.\/</h3>
+
+<h1 id="myid">Heading with ID</h1>

--- a/test/tests/header_id.txt
+++ b/test/tests/header_id.txt
@@ -5,3 +5,5 @@
 ## no ascii 中文
 
 ### special characters � '`"|,.\/
+
+# Heading with ID {#myid}


### PR DESCRIPTION
Added an `autoIds` option in `Renderer`.  Defaults to `true`.

Setting it to `false` in the `Renderer` or `kramed.defaults` will disable creating ids.
```javascript
kramed.setOptions({
    autoIds: false,
    renderer: false // must be recreated by Parser to get options
});
```

Also adjusts the regex to require a space between content and the id declaration per
http://kramdown.gettalong.org/syntax.html#specifying-a-header-id

That space will be removed in the output:
`# Header {#myid}` -> `<h1 id="myid">Header</h1>`

Includes a few changes to pass renderer options to `Parser` and merge them in `Renderer`.