### PR TITLE
Wrap footnote in a <p> tag

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -148,9 +148,11 @@ Renderer.prototype.reffn = function(refname) {
 
 Renderer.prototype.footnote = function(refname, text) {
   return '<blockquote id="fn_' + refname + '">\n'
+    + '<p>'
     + '<sup>' + refname + '</sup>. '
     + text
     + '<a href="#reffn_' + refname + '" title="Jump back to footnote [' + refname + '] in the text."> &#8617;</a>\n'
+    + '</p>'
     + '</blockquote>\n';
 }
 

--- a/test/tests/footnotes.html
+++ b/test/tests/footnotes.html
@@ -1,4 +1,6 @@
 <p>This is some text<sup><a href="#fn_1" id="reffn_1">1</a></sup>.</p>
 <blockquote id="fn_1">
+<p>
 <sup>1</sup>. Some <em>crazy</em> footnote definition.<a href="#reffn_1" title="Jump back to footnote [1] in the text."> &#8617;</a>
+</p>
 </blockquote>


### PR DESCRIPTION
Ensures that the parser produces valid XHTML for footnotes. The
`<blockquote>` should contain another block-level element like `<p>` or
`<div>`.

Addresses GitbookIO/gitbook#1144. With this fix, footnotes will pass
IDPF/epubcheck's EPUB version 2.0.1 rules.
