### PR TITLE
Improve heading id creation

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -51,7 +51,7 @@ Renderer.prototype.html = function(html) {
 
 Renderer.prototype._createId = function(str) {
   // replace " " and all punctuation characters to "-"
-  str = str.toLowerCase().replace(/[\s\]\[\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\`\{\|\}\~\-]+/g, '-');
+  str = str.toLowerCase().replace(/[\s\]\[\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\`\{\|\}\~\-؟]+/g, '-');
   try {
     str = encodeURIComponent(str);
   } catch (e) {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -57,7 +57,7 @@ Renderer.prototype._createId = function(str) {
   } catch (e) {
     str = str.replace(/[^\w]+/g, '-');
   }
-  return str.replace(/-$/, '');
+  return str.replace(/(^-+)|(-+$)/g, '');
 };
 
 Renderer.prototype.heading = function(text, level, raw) {

--- a/test/tests/header_id.html
+++ b/test/tests/header_id.html
@@ -5,3 +5,5 @@
 <h2 id="no-ascii-%E4%B8%AD%E6%96%87">no ascii 中文</h2>
 
 <h3 id="special-characters-%EF%BF%BD">special characters � &#39;`&quot;|,.\/</h3>
+
+<h3 id="leading-punctuation">!leading punctuation</h3>

--- a/test/tests/header_id.html
+++ b/test/tests/header_id.html
@@ -6,4 +6,4 @@
 
 <h3 id="special-characters-%EF%BF%BD">special characters � &#39;`&quot;|,.\/</h3>
 
-<h3 id="leading-punctuation">!leading punctuation</h3>
+<h3 id="leading-punctuation">؟leading punctuation</h3>

--- a/test/tests/header_id.txt
+++ b/test/tests/header_id.txt
@@ -5,3 +5,5 @@
 ## no ascii 中文
 
 ### special characters � '`"|,.\/
+
+### !leading punctuation

--- a/test/tests/header_id.txt
+++ b/test/tests/header_id.txt
@@ -6,4 +6,4 @@
 
 ### special characters � '`"|,.\/
 
-### !leading punctuation
+### ؟leading punctuation


### PR DESCRIPTION
Fixes two problems I was having with automatic heading tag id generation.
- Remove any leading hyphens (in addition to trailing ones)
- Consider ؟ mirrored question mark as punctuation to be removed

I noticed this issue in an Arabic gitbook with a heading that begins with a question mark. The resulting markup was not valid for an EPUB.
